### PR TITLE
Switch to one-line install

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,7 @@ your git repositories.
 ## Install
 
 ```
-$ curl https://raw.githubusercontent.com/joshfriend/hooker/master/hooker.sh
-$ ./hooker.sh --install
+$ bash <(curl -s https://raw.githubusercontent.com/joshfriend/hooker/master/hooker.sh) --install
 Hooking you up...
 ```
 


### PR DESCRIPTION
This will be easier to copy and won’t leave the script on disk.
